### PR TITLE
ci: ignore semver-major eslint bumps pending flat-config migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "npm"
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
     directory: "/"
     open-pull-requests-limit: 20
     schedule:


### PR DESCRIPTION
eslint 8→10 requires the flat-config migration, which will be done deliberately fleet-wide (2026-07-07 improvement plan, W2). Until then these major bumps fail CI on every repo and clog the Dependabot queue — ignore them; minors/patches still flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)